### PR TITLE
Fixed "ReferenceError: _gaq is not defined" in navigate() function

### DIFF
--- a/fw/views/wrapper.blade.php
+++ b/fw/views/wrapper.blade.php
@@ -450,11 +450,13 @@
 												console.info( "Successfully AJAX navigated to " + href );
 											}
 
-											if( _gaq )
-											{
-												// Send ajax analytic data to Google
-												_gaq.push( ['_setReferrerOverride', referrer] );
-												_gaq.push( ['_trackPageview', href] );
+											if ( typeof _gaq !== "undefined") {
+												if( _gaq )
+												{
+													// Send ajax analytic data to Google
+													_gaq.push( ['_setReferrerOverride', referrer] );
+													_gaq.push( ['_trackPageview', href] );
+												}
 											}
 										}
 								).fail(

--- a/fw/views/wrapper.blade.php
+++ b/fw/views/wrapper.blade.php
@@ -450,7 +450,8 @@
 												console.info( "Successfully AJAX navigated to " + href );
 											}
 
-											if ( typeof _gaq !== "undefined") {
+											if( typeof _gaq !== "undefined" )
+											{
 												if( _gaq )
 												{
 													// Send ajax analytic data to Google


### PR DESCRIPTION
Instead of `if (_gaq )`, I added a check for ` if ( _gaq !== "undefined" )`. This should silence all the bugs when attempting to navigate via pages when `analytics.js` is not loaded.